### PR TITLE
ルートオブジェクトの生成方法を変更

### DIFF
--- a/app/javascript/src/canvas.js
+++ b/app/javascript/src/canvas.js
@@ -7,64 +7,78 @@ import { setFacilityDataToModal } from "src/simulation";
 import { setRouteDataToModal } from "src/simulation";
 import { facilityDialog, routeDialog } from "src/simulation";
 export async function drawLink(linksData, nodesData) {
-  d3.select("#svg02").selectAll("line").remove();
-  d3.select("#svg02").selectAll("circle").remove();
+  return new Promise((resolve) => {
+    d3.select("#svg02").selectAll("line").remove();
+    d3.select("#svg02").selectAll("circle").remove();
 
-  link = d3
-    .select("#svg02")
-    .selectAll("line")
-    .data(linksData)
-    .enter()
-    .append("line")
-    .attr("stroke-width", 8)
-    .attr("stroke", "black")
-    .attr("id", function (d) {
-      return d.id;
-    });
-
-  node = d3
-    .select("#svg02")
-    .selectAll("circle")
-    .data(nodesData)
-    .enter()
-    .append("circle")
-    .attr("r", function (d) {
-      return d.r;
-    })
-    .attr("stroke", "black")
-    .attr("fill", "LightSalmon")
-    .attr("id", function (d) {
-      return d.id;
-    });
-
-  const simurateSvg = document.getElementById("svg02");
-  if (simurateSvg) {
-    // シミュレーション描画
-    simulation = d3
-      .forceSimulation()
-      .force("link", d3.forceLink().strength(0))
-      .force("charge", d3.forceManyBody().strength(0))
-      .force("x", null)
-      .force("y", null);
-
-    simulation.nodes(nodesData).on("tick", ticked);
-    node
-      .call(
-        d3
-          .drag()
-          .on("start", dragstarted)
-          .on("drag", dragged)
-          .on("end", dragended)
-      )
-      .on("click", nodeClicked);
-    link.on("click", linkClicked);
-    simulation
-      .force("link")
-      .links(linksData)
-      .id(function (d) {
-        return d.index;
+    link = d3
+      .select("#svg02")
+      .selectAll("line")
+      .data(linksData)
+      .enter()
+      .append("line")
+      .attr("stroke-width", 8)
+      .attr("stroke", "black")
+      .attr("id", function (d) {
+        return d.id;
       });
-  }
+
+    node = d3
+      .select("#svg02")
+      .selectAll("circle")
+      .data(nodesData)
+      .enter()
+      .append("circle")
+      .attr("r", function (d) {
+        return d.r;
+      })
+      .attr("stroke", "black")
+      .attr("fill", "LightSalmon")
+      .attr("id", function (d) {
+        return d.id;
+      });
+
+    const simurateSvg = document.getElementById("svg02");
+    if (simurateSvg) {
+      // シミュレーション描画
+      simulation = d3
+        .forceSimulation()
+        .force("link", d3.forceLink().strength(0))
+        .force("charge", d3.forceManyBody().strength(0))
+        .force("x", null)
+        .force("y", null);
+
+      simulation.nodes(nodesData).on("tick", ticked);
+      node
+        .call(
+          d3
+            .drag()
+            .on("start", dragstarted)
+            .on("drag", dragged)
+            .on("end", dragended)
+        )
+        .on("click", nodeClicked);
+      link.on("click", linkClicked);
+      simulation
+        .force("link")
+        .links(linksData)
+        .id(function (d) {
+          return d.index;
+        });
+      // シミュレーションが完全に終了したら resolve を呼び出す
+      simulation.on("end", () => {
+        resolve();
+      });
+
+      // 手動でシミュレーション終了
+      setTimeout(() => {
+        simulation.stop();
+        resolve();
+      }, 1000); // 1秒後にシミュレーションを強制終了
+    } else {
+      resolve(); // SVGが存在しない場合もresolveを呼び出す
+    }
+  });
 }
 
 export function nodeClicked() {

--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -1,6 +1,6 @@
 import anime from "animejs";
 import { routes, facilities } from "src/set_simulation_params";
-// import { routes, operators, facilities } from "src/set_simulation_params";
+import { drawLink } from "src/canvas";
 
 class Location {
   constructor(parameters) {
@@ -97,9 +97,30 @@ class Controller {
   }
 }
 
-function countStart() {
-  let linksData = routes;
+function generatePairRoutes(routes) {
+  let lastIds = routes.filter((element) => element.lastId);
+  let filterdRoutes = routes.filter((element) => element.routeLength);
+  let routesWithPairs = filterdRoutes;
+
+  let converdRoutes = filterdRoutes.map((element) => {
+    return {
+      ...element,
+      source: element.target,
+      target: element.source,
+      id: `re-${element.id}`,
+    };
+  });
+  routesWithPairs = filterdRoutes.concat(converdRoutes);
+  if (lastIds.length == 0) {
+    return routesWithPairs;
+  } else {
+    return routesWithPairs.unshift(lastIds);
+  }
+}
+async function countStart() {
+  let linksData = generatePairRoutes(routes);
   let nodesData1 = facilities;
+  await drawLink(linksData, nodesData1);
 
   const contoller = new Controller();
   let locations = [];
@@ -320,7 +341,7 @@ function getAnimeObject(rootName) {
     // duration: 500,
     direction: "reverse",
     // loop: true,
-    // easing: "linear",
+    // easing: "easeInOutSine",
   };
 
   return animeObject;

--- a/app/javascript/src/set_simulation_params.js
+++ b/app/javascript/src/set_simulation_params.js
@@ -8,9 +8,6 @@ const routesInitial = [
   { source: 0, target: 1, routeLength: 20, id: "root10" },
   { source: 1, target: 2, routeLength: 20, id: "root11" },
   { source: 2, target: 0, routeLength: 20, id: "root12" },
-  { source: 0, target: 2, routeLength: 20, id: "re_root10" },
-  { source: 1, target: 0, routeLength: 20, id: "re_root11" },
-  { source: 2, target: 1, routeLength: 20, id: "re_root12" },
 ];
 const operatorsInitial = [{ name: "Alice" }];
 const facilitiesInitial = [
@@ -91,6 +88,7 @@ document.addEventListener("turbo:load", async () => {
       operators = operatorsInitial;
       facilities = facilitiesInitial;
       console.log("初期値設定終了");
+      drawLink(routes, facilities);
     } else {
       try {
         const response = await fetch("edit.json");

--- a/app/javascript/src/simulation.js
+++ b/app/javascript/src/simulation.js
@@ -88,14 +88,6 @@ export function setParamsToRouteOnModal() {
       params.routeLength = document.getElementById("route-length").value;
 
       setObjectparams(e, params, routes);
-      let selectedRoute = routes.find((route) => route.id == params.id);
-      let pairRoute = routes.find(
-        (route) =>
-          route.target == selectedRoute.source &&
-          route.source == selectedRoute.target
-      );
-      params.id = pairRoute.id;
-      setObjectparams(e, params, routes);
       routeDialog.close();
     });
   }


### PR DESCRIPTION
シミュレーションのルートの表現方法を変更した。


```
const routesInitial = [
  { source: 0, target: 1, routeLength: 20, id: "root10" },
  { source: 1, target: 2, routeLength: 20, id: "root11" },
  { source: 2, target: 0, routeLength: 20, id: "root12" },
];
```

このようにして、行き側のルートのみ宣言する。帰り側のルートはシミュレーション開始時に生成する。

これはルートの整合性確認機能を追加する前準備として行った。
ルートの数を行きだけに変更して、整合性確認（深さ優先探索）を行いやすくする。

