### PR TITLE
バリデーションが表示されるようにした

### DIFF
--- a/app/javascript/src/simulation.js
+++ b/app/javascript/src/simulation.js
@@ -3,7 +3,12 @@ import { routes, operators, facilities } from "src/set_simulation_params";
 // データの初期値をロード
 
 export let link, node, simulation;
-export let facilityDialog, confirmBtn, routeDialog, routeConfirmBtn;
+export let facilityDialog,
+  confirmBtn,
+  routeDialog,
+  routeConfirmBtn,
+  facilityForm,
+  routeForm;
 import {
   addFacility,
   addRoute,
@@ -66,7 +71,6 @@ export function switchAddRouteMode() {
 }
 
 export function setObjectparams(e, params, objects) {
-  e.preventDefault(); // この偽フォームを送信しない
   let id = params.id;
   let selectedObject = objects.find((object) => object.id == id);
   for (const [key, value] of Object.entries(params)) {
@@ -79,9 +83,16 @@ export function setObjectparams(e, params, objects) {
 export function setParamsToFacilityOnModal() {
   facilityDialog = document.getElementById("facilityDialog");
   confirmBtn = document.getElementById("confirmBtn");
+  facilityForm = document.getElementById("facility-form");
+  const cancelBtn = document.getElementById("cancel-btn");
+
   if (confirmBtn) {
     confirmBtn.addEventListener("click", (e) => {
-      // e.preventDefault();
+      if (!facilityForm.checkValidity()) {
+        facilityForm.reportValidity();
+        return;
+      }
+
       let params = {};
       params.id = document.getElementById("hidden-id").value;
       params.name = document.getElementById("name").value;
@@ -91,19 +102,38 @@ export function setParamsToFacilityOnModal() {
       facilityDialog.close();
     });
   }
+
+  if (cancelBtn) {
+    cancelBtn.addEventListener("click", () => {
+      facilityDialog.close();
+    });
+  }
 }
 
 export function setParamsToRouteOnModal() {
   routeDialog = document.getElementById("route-dialog");
   routeConfirmBtn = document.getElementById("route-confirm-btn");
+  routeForm = document.getElementById("route-form");
+  const routeCancelBtn = document.getElementById("route-cancel-btn");
+
   if (routeConfirmBtn) {
-    // ［確認］ボタンが既定でフォームを送信しないようにし、`close()` メソッドでダイアログを閉じ、"close" イベントを発生させる
     routeConfirmBtn.addEventListener("click", (e) => {
+      if (!routeForm.checkValidity()) {
+        routeForm.reportValidity();
+        return;
+      }
+
       let params = {};
       params.id = document.getElementById("route-hidden-id").value;
       params.routeLength = document.getElementById("route-length").value;
 
       setObjectparams(e, params, routes);
+      routeDialog.close();
+    });
+  }
+
+  if (routeCancelBtn) {
+    routeCancelBtn.addEventListener("click", () => {
       routeDialog.close();
     });
   }

--- a/app/views/simulations/_form.html.erb
+++ b/app/views/simulations/_form.html.erb
@@ -42,32 +42,32 @@ data-facilities ="<%= @simulation.facilities %>">
     <dialog id="facilityDialog">
     パラメータ
       <div id="hidden-id" hidden></div>
-      <form>
+      <form id="facility-form">
         <div>
           <label for="name">設備名</label>
           <input type="text" id="name" name="name" maxlength="16" size="15" />
         </div>
         <div>
           <label for="processingTime">加工時間</label>
-          <input type="number" id="processingTime" name="name" min="0" max="400" />
+          <input type="number" id="processingTime" name="name" min="1" max="400" />
         </div>
         <div>
-          <button value="cancel" formmethod="dialog">取り消し</button>
-          <button id="confirmBtn" value="default">保存</button>
+          <button type="button" id="cancel-btn" formmethod="dialog">取り消し</button>
+          <button type="button" id="confirmBtn" value="default">保存</button>
         </div>
       </form>
     </dialog>
     <dialog id="route-dialog">
       パラメータ
       <div id="route-hidden-id" hidden></div>
-      <form>
+      <form id="route-form">
         <div>
           <label for="route-length">距離</label>
           <input type="number" id="route-length" name="root-length" min="1" max="50" />
         </div>
         <div>
-          <button value="cancel" formmethod="dialog">取り消し</button>
-          <button id="route-confirm-btn" value="default">保存</button>
+          <button type="button" id="route-cancel-btn" value="cancel" formmethod="dialog">取り消し</button>
+          <button type="button" id="route-confirm-btn" value="default">保存</button>
         </div>
       </form>
     </dialog>


### PR DESCRIPTION
設備やルートのパラメーターを変更する際の処理を修正した。

今まではモーダルが表示され、バリデーションに違反する数字を入力しても保存され、モーダルが閉じてしまっていた。

`checkValidity()`と`reportValidity()` メソッドを使うことで

バリデーションに違反しているかを判定し、違反していたらエラーメッセージを出すようにした。