### PR TITLE
移動時間をアニメーションに考慮させる/シミュレーション速度の導入

### DIFF
--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -61,7 +61,7 @@ class Controller {
   }
 
   determineRoute(operator) {
-    let selectedRoot, rootName, destination, roots, currentLocation;
+    let selectedRoot, destination, roots, currentLocation;
     roots = this.route;
     currentLocation = operator.currentLocation;
     switch (operator.currentLocation.type) {
@@ -92,8 +92,7 @@ class Controller {
         break;
     }
 
-    rootName = selectedRoot.id;
-    return { destination, rootName };
+    return { destination, selectedRoot };
   }
 }
 
@@ -132,7 +131,7 @@ document.addEventListener("turbo:load", () => {
     tl = anime.timeline({
       easing: "easeOutExpo",
       autoplay: false,
-      update: function () {
+      change: function () {
         controlsProgress.value = tl.progress;
       },
     });
@@ -183,7 +182,7 @@ async function countStart() {
   let totalCount = 0;
 
   object3 = getCountObject(totalCount);
-  tl.add(object3, t * 100);
+  tl.add(object3, t * 1000);
 
   let machine;
   while (t < endTime) {
@@ -206,7 +205,7 @@ async function countStart() {
           machine = locations.find(
             (elemnt) => elemnt.id == operator1.currentLocation.id
           );
-          if (!machine.isProcessing || machine.processingEndTime < t) {
+          if (!machine.isProcessing || Number(machine.processingEndTime) < t) {
             operator1.addStateToHistory(t, "脱着中");
             if (!machine.hasMaterial) {
               operator1.hasMaterial = false;
@@ -214,14 +213,14 @@ async function countStart() {
             machine.isProcessing = true;
             machine.hasMaterial = true;
             operator1.isWaiting = false;
-            machine.processingEndTime = t + machine.processingTime;
+            machine.processingEndTime = t + Number(machine.processingTime);
             object2 = getMachineAnimeObject();
-            tl.add(object2, t * 100)
+            tl.add(object2, t * 1000)
               .add({
                 targets: "circle#\\31",
                 easing: "steps(1)",
                 fill: "#00f",
-                duration: machine.processingTime * 1000,
+                duration: Number(machine.processingTime) * 1000,
               })
               .add({
                 targets: "circle#\\31",
@@ -229,7 +228,7 @@ async function countStart() {
                 fill: "#000",
                 duration: 100,
               });
-            // console.log(tl);
+            console.log(tl);
           } else {
             operator1.isWaiting = true;
             // if ()
@@ -245,22 +244,22 @@ async function countStart() {
           break;
 
         case "goal":
-          // console.log(`goal :t=${t}`);
+          console.log(`goal :t=${t}`);
           operator1.addStateToHistory(t, "脱着中");
           operator1.hasMaterial = false;
           totalCount = totalCount + 1;
           goalPoint.storageSize++;
           goalPoint.addCountToHistory(t, goalPoint.storageSize);
           object3 = getCountObject(totalCount);
-          tl.add(object3, t * 100);
+          tl.add(object3, t * 1000);
           break;
       }
 
       if (!operator1.isWaiting) {
-        operator1.arrivalTime = t + 20;
-        let { destination, rootName } = contoller.determineRoute(operator1);
-        object1 = getAnimeObject(rootName);
-        tl.add(object1, t * 100);
+        let { destination, selectedRoot } = contoller.determineRoute(operator1);
+        operator1.arrivalTime = t + Number(selectedRoot.routeLength);
+        object1 = getAnimeObject(selectedRoot);
+        tl.add(object1, t * 1000);
         operator1.destination = destination;
         operator1.isMoving = true;
       }
@@ -268,8 +267,8 @@ async function countStart() {
 
     locations.forEach((machine) => {
       if (machine.isProcessing) {
-        if (machine.processingEndTime == t) {
-          // console.log("加工終了");
+        if (Number(machine.processingEndTime) == t) {
+          console.log("加工終了");
           machine.isProcessing = false;
         }
       }
@@ -354,35 +353,36 @@ export function calculateCycleTime(goalPoint) {
 }
 
 function getCountObject(countSize) {
-  let count = {
-    totalCount: countSize,
-  };
+  // let count = {
+  //   totalCount: countSize,
+  // };
   let JSobjectProp = anime({
-    targets: count,
-    totalCount: countSize,
+    // targets: count,
+    // totalCount: countSize,
     easing: "linear",
-    round: 1,
-    value: countSize,
+    // round: 100,
+    // duration: 10,
+    // value: countSize,
     change: function () {
       var el = document.querySelector("#JSobjectProp pre");
-      el.innerHTML = JSON.stringify(count);
+      el.innerHTML = JSON.stringify(`totalCount: ${countSize}`);
     },
   });
 
   return JSobjectProp;
 }
 
-function getAnimeObject(rootName) {
-  let path = anime.path(`#svg02 line#${rootName}`);
+function getAnimeObject(root) {
+  let path = anime.path(`#svg02 line#${root.id}`);
   let animeObject = {
     targets: "#ob1",
     translateX: path("x"),
     translateY: path("y"),
     // direction: "alternate",
-    // duration: 500,
+    duration: Number(root.routeLength) * 1000,
     direction: "reverse",
     // loop: true,
-    // easing: "easeInOutSine",
+    easing: "linear",
   };
 
   return animeObject;

--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -121,6 +121,8 @@ let tl = anime.timeline({
   autoplay: false,
 });
 
+let countHistory = [{ t: 0, productionCount: 0 }];
+
 document.addEventListener("turbo:load", () => {
   const start = document.getElementById("startSimulation2");
   const play = document.getElementById("play");
@@ -138,6 +140,9 @@ document.addEventListener("turbo:load", () => {
 
     controlsProgress.oninput = function () {
       tl.seek(tl.duration * (controlsProgress.value / 100));
+
+      let t = tl.duration * (controlsProgress.value / 100);
+      dispCount(t / 1000);
     };
   }
 
@@ -155,6 +160,28 @@ document.addEventListener("turbo:load", () => {
     });
   }
 });
+
+function dispCount(t) {
+  countHistory;
+  let closestTime, count;
+  let timeSeries = countHistory.map((el) => el.t);
+  if (timeSeries[0] > t) {
+    closestTime = 0;
+    count = 0;
+  } else {
+    closestTime = timeSeries.reduce((a, current) => {
+      if (Math.abs(current - t) < Math.abs(a - t) && current < t) {
+        return current;
+      } else {
+        return a;
+      }
+    });
+    count = countHistory.filter((el) => el.t == closestTime)[0].productionCount;
+  }
+  // let count = t;
+  let el = document.querySelector("#JSobjectProp pre");
+  el.innerHTML = JSON.stringify(`total:${count}`);
+}
 
 async function countStart() {
   tl.children = [];
@@ -277,7 +304,7 @@ async function countStart() {
   }
 
   // 結果出力
-
+  countHistory = goalPoint.history;
   let cycleTime = calculateCycleTime(goalPoint);
   let waitingArray = formatStateHistory(operator1);
   let waitingTime = calculateWaitingTime(waitingArray);
@@ -353,19 +380,23 @@ export function calculateCycleTime(goalPoint) {
 }
 
 function getCountObject(countSize) {
-  // let count = {
-  //   totalCount: countSize,
-  // };
+  let count = {
+    totalCount: 300,
+  };
+
+  // count.totalCount = countSize;
   let JSobjectProp = anime({
-    // targets: count,
-    // totalCount: countSize,
+    targets: count,
+    totalCount: countSize,
     easing: "linear",
-    // round: 100,
+    round: 1,
     // duration: 10,
-    // value: countSize,
-    change: function () {
+    update: function () {
       var el = document.querySelector("#JSobjectProp pre");
-      el.innerHTML = JSON.stringify(`totalCount: ${countSize}`);
+      el.innerHTML = JSON.stringify(`${count}`);
+      console.log(count);
+      // el.innerHTML = JSON.stringify(`totalCount: ${count.value}`);
+      // console.log(anim.value);
     },
   });
 

--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -142,7 +142,6 @@ document.addEventListener("turbo:load", () => {
     controlsProgress.oninput = function () {
       let targetAnimetionSecond = tl.duration * (controlsProgress.value / 100);
       let targetSecond = (targetAnimetionSecond / 1000) * simulationSpeedRatio;
-      console.log(tl.duration);
       tl.seek(targetAnimetionSecond);
       dispCount(targetSecond);
     };
@@ -210,7 +209,6 @@ async function countStart() {
   let t = 0;
   let object1, object2;
   let totalCount = 0;
-  let scaledTime;
 
   let machine;
   while (t < endTime) {
@@ -229,7 +227,7 @@ async function countStart() {
     } else {
       switch (operator1.currentLocation.type) {
         case "machine":
-          // console.log(`加工地点 :t=${t}`);
+          console.log(`加工地点 :t=${t}`);
           machine = locations.find(
             (elemnt) => elemnt.id == operator1.currentLocation.id
           );
@@ -243,16 +241,13 @@ async function countStart() {
             operator1.isWaiting = false;
             machine.processingEndTime = t + Number(machine.processingTime);
             object2 = getMachineAnimeObject();
-            scaledTime = (t * 1000) / simulationSpeedRatio;
-
-            tl.add(object2, scaledTime)
+            tl.add(object2, (t * 1000) / simulationSpeedRatio)
               .add({
                 targets: "circle#\\31",
                 easing: "steps(1)",
                 fill: "#00f",
                 duration:
-                  (Number(machine.processingTime) * 1000) /
-                  simulationSpeedRatio,
+                  (machine.processingTime * 1000) / simulationSpeedRatio,
               })
               .add({
                 targets: "circle#\\31",
@@ -289,7 +284,7 @@ async function countStart() {
         let { destination, selectedRoot } = contoller.determineRoute(operator1);
         operator1.arrivalTime = t + Number(selectedRoot.routeLength);
         object1 = getAnimeObject(selectedRoot);
-        tl.add(object1, scaledTime);
+        tl.add(object1, (t * 1000) / simulationSpeedRatio);
         operator1.destination = destination;
         operator1.isMoving = true;
       }
@@ -388,10 +383,8 @@ function getAnimeObject(root) {
     targets: "#ob1",
     translateX: path("x"),
     translateY: path("y"),
-    // direction: "alternate",
-    duration: (Number(root.routeLength) * 1000) / simulationSpeedRatio,
+    duration: (root.routeLength * 1000) / simulationSpeedRatio,
     direction: "reverse",
-    // loop: true,
     easing: "linear",
   };
 


### PR DESCRIPTION
ルート間の移動時間が、アニメーションに適用していなかった。追加する。

シミュレーション時間が実際の加工時間のままだとアニメーションが長くなってしまう。
倍率を設定する。