### PR TITLE
整合性確認とシミュレーションスタートを一つのボタンで動作するようにした

### DIFF
--- a/app/javascript/controllers/simulationmode_controller.js
+++ b/app/javascript/controllers/simulationmode_controller.js
@@ -4,6 +4,7 @@ import { changeActiveObject, drawLink } from "src/canvas";
 import { setClickEventToObject } from "src/simulation";
 import { routes } from "src/set_simulation_params";
 import { findInvalidRouteIds } from "src/consistency_check";
+import { countStart } from "src/exec_simulation";
 
 export default class extends Controller {
   static targets = ["edit", "simulate", "editbutton", "simulatebutton"];
@@ -70,28 +71,37 @@ export default class extends Controller {
     setClickEventToObject(this);
   }
 
-  checkSimulate() {
-    if (this.readyForExecution) {
-      this.simulate();
-    } else {
-      alert("整合性確認を行なってください");
-      const editRadio = document.getElementById("editMode");
-      editRadio.checked = true;
+  async startSimulation() {
+    let isConsistency = this.isConsistency();
+    drawLink();
+    if (!isConsistency) {
+      alert("異常なルートがあります。削除してください。");
+      return;
     }
+    alert("整合性チェックOK");
+    this.readyForExecution = true;
+    await countStart();
+    const play = document.getElementById("play");
+    const pause = document.getElementById("pause");
+    const progress = document.getElementById("progress");
+    play.disabled = false;
+    pause.disabled = false;
+    progress.disabled = false;
   }
 
-  checkConsistency() {
+  checkSimulate() {
+    this.simulate();
+  }
+
+  isConsistency() {
     let result = findInvalidRouteIds(routes);
     console.log(`整合性チェックの結果: ${result.ids}`);
     if (result.ids.length == 0) {
-      alert("整合性チェックOK");
-      const simulateRadio = document.getElementById("simulateMode");
-      simulateRadio.disabled = false;
       this.readyForExecution = true;
+      return true;
     } else {
-      alert("異常なルートがあります。削除してください。");
+      return false;
     }
-    drawLink();
   }
 
   simulate() {

--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -185,7 +185,7 @@ function dispCount(t) {
   el.innerHTML = JSON.stringify(`total:${count}`);
 }
 
-async function countStart() {
+export async function countStart() {
   tl.children = [];
 
   let linksData = generatePairRoutes(routes);

--- a/app/views/simulations/_form.html.erb
+++ b/app/views/simulations/_form.html.erb
@@ -35,9 +35,7 @@ data-facilities ="<%= @simulation.facilities %>">
     </div>
   <% end %>
 <% end %>
-  <div id="JSobjectProp">
-    <pre class="count">{"パラメータ":0}</pre>
-  </div>
+
   <!-- フォームを含むモーダルダイアログ -->
     <dialog id="facilityDialog">
     パラメータ
@@ -86,7 +84,7 @@ data-facilities ="<%= @simulation.facilities %>">
           <span class="px-2 font-medium text-gray-900 group-has-[:checked]:text-indigo-900">編集</span>
         </span>
       </label>
-      <button type="button" id="checkConsistency" data-action="simulationmode#checkConsistency" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">整合性確認</button>
+
       <label aria-description="edit" class="group flex cursor-pointer border border-gray-200 p-4 first:rounded-tl-md first:rounded-tr-md last:rounded-bl-md last:rounded-br-md focus:outline-none has-[:checked]:relative has-[:checked]:border-indigo-200 has-[:checked]:bg-indigo-50 md:grid md:grid-cols-3 md:pl-4 md:pr-6">
         <span class="flex items-center gap-3">
           <input
@@ -95,7 +93,7 @@ data-facilities ="<%= @simulation.facilities %>">
             id="simulateMode"
             data-simulationmode-target="simulatebutton" data-action="simulationmode#checkSimulate"
             class="relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400"
-            disabled >
+          >
             <span class="px-2 font-medium text-gray-900 group-has-[:checked]:text-indigo-900">実行</span>
         </span>
       </label>
@@ -132,10 +130,13 @@ data-facilities ="<%= @simulation.facilities %>">
       </div>
       <div data-simulationmode-target="simulate" id="simulation">
         <h3>実行モード</h3>
-        <button type="button" id="startSimulation2" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">シミュレーション実行</button>
-        <button type="button" id="play" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">再生</button>
-        <button type="button" id="pause" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">停止</button>
-        <input class="progress" step=".001" min="0" max="100" value="0" type="range"></input>
+        <button type="button" id="isConsistency" data-action="simulationmode#startSimulation" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">シミュレーション開始</button>
+        <button type="button" id="play" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" disabled>再生</button>
+        <button type="button" id="pause" class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" disabled>停止</button>
+        <input id="progress" class="progress" step=".001" min="0" max="100" value="0" type="range" disabled></input>
+        <div id="JSobjectProp">
+        <pre class="count">{総生産数}</pre>
+      </div>
       </div>
     </fieldset>
   </div>

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -16,13 +16,4 @@ RSpec.describe 'Widget', type: :system do
     expect(page).to have_css 'circle#\\31'
     expect(page).to have_css 'circle#goal'
   end
-
-  it 'can not fire click event in simulation mode', js: true do
-    sign_in @user
-    visit new_user_simulation_path(@user)
-    accept_alert '整合性チェックOK' do
-      click_on '整合性確認'
-    end
-    expect(page).to have_no_selector 'input#simulateMode[disabled]'
-  end
 end


### PR DESCRIPTION
#101 の内容

編集モードと実行モードの切り替えは自在にできるようにした。
実行モードの中の再生・停止・シークバーは非アクティブにしておき、
整合性確認がとれたらアクティブになるようにした。

