### PR TITLE
ランディングページ変更

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,3 @@
+class WelcomeController < ApplicationController
+  def index; end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       <div class="relative flex h-16 items-center justify-between">
         <div class="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
           <div class="flex flex-shrink-0 items-center text-white">
-           lytcycle
+           <%= link_to "lytcycle", welcome_index_url ,class: "nav-link2 text-white" %>
           </div>
           <div class="hidden sm:ml-6 sm:block">
             <div class="flex space-x-4">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,0 +1,8 @@
+<main class="container mx-auto px-4">
+    <h1 class="font-bold text-4xl pt-5">最適化の第一歩を、シンプルに。</h1>
+    <p class="mt-4 text-sm/6">lytcycle （ライトサイクル）は、製造業向けの簡易な生産ラインシミュレータです。</p>
+
+    <%= button_to "早速使ってみる", demo_path ,class:"rounded-md bg-white my-4 px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+    <%= button_to "新規登録", new_user_registration_path, method: :get, class:"rounded-md bg-white my-4 px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,14 @@
 Rails.application.routes.draw do
+  get 'welcome/index'
   devise_for :users
   resources :users do
     resources :simulations
   end
   resources :simurates
   get 'demo' , to: 'simulations#demo'
-
   resource :term, only: [:show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
-  root "simurates#index"
+  root "welcome#index"
 end

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class WelcomeControllerTest < ActionDispatch::IntegrationTest
+  # test "should get index" do
+  #   get welcome_index_url
+  #   assert_response :success
+  # end
+end


### PR DESCRIPTION
ページの内容を変更。

welcomeページを作成し、ルーティングを変更。はじめに表示されるページにした。

ヘッダーのタイトル部分をクリックするとトップページに遷移するようにした。