### PR TITLE
シミュレーション画面を見やすくした

### DIFF
--- a/app/javascript/src/canvas.js
+++ b/app/javascript/src/canvas.js
@@ -11,10 +11,20 @@ import {
   facilityDialog,
   routeDialog,
 } from "src/simulation";
+
+export async function displayOperator() {
+  d3.select("#svg02").append("text").attr("id", "ob1").text("作業者");
+}
+
+export async function displayStartGoalName() {
+  d3.select("#svg02").selectAll("circle").select("#start").text("スタート");
+  d3.select("#svg02").selectAll("circle").select("#goal").text("ゴール");
+}
+
 export async function drawLink(linksData = routes, nodesData = facilities) {
   return new Promise((resolve) => {
     d3.select("#svg02").selectAll("line").remove();
-    d3.select("#svg02").selectAll("circle").remove();
+    d3.select("#svg02").selectAll("g").remove();
     function ticked() {
       link
         .attr("x1", (d) => d.source.x)
@@ -22,7 +32,8 @@ export async function drawLink(linksData = routes, nodesData = facilities) {
         .attr("x2", (d) => adjustLinkEnd(d).x)
         .attr("y2", (d) => adjustLinkEnd(d).y);
 
-      node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
+      // node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
+      node.attr("transform", (d) => `translate(${d.x}, ${d.y})`);
     }
 
     function adjustLinkEnd(link) {
@@ -52,19 +63,62 @@ export async function drawLink(linksData = routes, nodesData = facilities) {
         })
         .attr("marker-end", (d) => (d.id.includes("re") ? "" : "url(#arr)"));
 
+      // node = d3
+      // .select("#svg02")
+      // .selectAll("circle")
       node = d3
         .select("#svg02")
-        .selectAll("circle")
+        .selectAll("g") // g要素単位でデータをバインド
         .data(nodesData)
         .enter()
+        .append("g") // g要素を追加して circle + text をグルーピング
+        .attr("transform", (d) => `translate(${d.x}, ${d.y})`);
+      // .call(
+      //   d3
+      //     .drag()
+      //     .on("start", function () {
+      //       alert("start");
+      //     })
+      //     .on("drag", dragged)
+      //     .on("end", dragended)
+      // ); // 初期位置
+      // .call(
+      //   d3.drag().on("drag", function (event, d) {
+      //     d.x = event.x;
+      //     d.y = event.y;
+      //     d3.select(this).attr("transform", `translate(${d.x}, ${d.y})`);
+      //   })
+      // );
+
+      // circleをg内に追加
+      node
         .append("circle")
-        .attr("r", function (d) {
-          return d.r;
-        })
-        .attr("stroke", "black")
-        .attr("id", function (d) {
-          return d.id;
-        });
+        .attr("r", (d) => d.r)
+        .attr("stroke", "black") // 任意の色
+        .attr("id", (d) => d.id);
+
+      // textをg内に追加（circleの中央または外側）
+      node
+        .append("text")
+        .text((d) => d.id)
+        .attr("text-anchor", "middle") // 中央揃え
+        .attr("y", 25); // 垂直方向の調整（中央に見せる）
+      // .attr("font-size", "12px")
+      // .attr("pointer-events", "none"); // ドラッグイベントの妨げにならないように
+
+      // node = d3
+      //   .select("#svg02")
+      //   .selectAll("circle")
+      //   .data(nodesData)
+      //   .enter()
+      //   .append("circle")
+      //   .attr("r", function (d) {
+      //     return d.r;
+      //   })
+      //   .attr("stroke", "black")
+      //   .attr("id", function (d) {
+      //     return d.id;
+      //   });
 
       setNodeColor(nodesData, "#99aaee");
       setLinkColor(linksData, "#aaa");
@@ -141,6 +195,7 @@ export async function drawLink(linksData = routes, nodesData = facilities) {
     } else {
       resolve();
     }
+    displayStartGoalName();
     inactivePlayButtons();
   });
 }

--- a/app/javascript/src/canvas.js
+++ b/app/javascript/src/canvas.js
@@ -16,6 +16,10 @@ export async function displayOperator() {
   d3.select("#svg02").append("text").attr("id", "ob1").text("作業者");
 }
 
+export async function displayRaiseOperator() {
+  d3.select("#ob1").raise();
+}
+
 export async function displayStartGoalName() {
   d3.select("#svg02").selectAll("circle").select("#start").text("スタート");
   d3.select("#svg02").selectAll("circle").select("#goal").text("ゴール");
@@ -32,7 +36,6 @@ export async function drawLink(linksData = routes, nodesData = facilities) {
         .attr("x2", (d) => adjustLinkEnd(d).x)
         .attr("y2", (d) => adjustLinkEnd(d).y);
 
-      // node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
       node.attr("transform", (d) => `translate(${d.x}, ${d.y})`);
     }
 
@@ -63,62 +66,25 @@ export async function drawLink(linksData = routes, nodesData = facilities) {
         })
         .attr("marker-end", (d) => (d.id.includes("re") ? "" : "url(#arr)"));
 
-      // node = d3
-      // .select("#svg02")
-      // .selectAll("circle")
       node = d3
         .select("#svg02")
-        .selectAll("g") // g要素単位でデータをバインド
+        .selectAll("g")
         .data(nodesData)
         .enter()
-        .append("g") // g要素を追加して circle + text をグルーピング
+        .append("g")
         .attr("transform", (d) => `translate(${d.x}, ${d.y})`);
-      // .call(
-      //   d3
-      //     .drag()
-      //     .on("start", function () {
-      //       alert("start");
-      //     })
-      //     .on("drag", dragged)
-      //     .on("end", dragended)
-      // ); // 初期位置
-      // .call(
-      //   d3.drag().on("drag", function (event, d) {
-      //     d.x = event.x;
-      //     d.y = event.y;
-      //     d3.select(this).attr("transform", `translate(${d.x}, ${d.y})`);
-      //   })
-      // );
 
-      // circleをg内に追加
       node
         .append("circle")
         .attr("r", (d) => d.r)
-        .attr("stroke", "black") // 任意の色
+        .attr("stroke", "black")
         .attr("id", (d) => d.id);
 
-      // textをg内に追加（circleの中央または外側）
       node
         .append("text")
         .text((d) => d.id)
-        .attr("text-anchor", "middle") // 中央揃え
-        .attr("y", 25); // 垂直方向の調整（中央に見せる）
-      // .attr("font-size", "12px")
-      // .attr("pointer-events", "none"); // ドラッグイベントの妨げにならないように
-
-      // node = d3
-      //   .select("#svg02")
-      //   .selectAll("circle")
-      //   .data(nodesData)
-      //   .enter()
-      //   .append("circle")
-      //   .attr("r", function (d) {
-      //     return d.r;
-      //   })
-      //   .attr("stroke", "black")
-      //   .attr("id", function (d) {
-      //     return d.id;
-      //   });
+        .attr("text-anchor", "middle")
+        .attr("y", 25);
 
       setNodeColor(nodesData, "#99aaee");
       setLinkColor(linksData, "#aaa");

--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -1,7 +1,7 @@
 import anime from "animejs";
 import { routes, facilities } from "src/set_simulation_params";
 import { drawLink } from "src/canvas";
-import { displayOperator } from "src/canvas";
+import { displayOperator, displayRaiseOperator } from "src/canvas";
 
 class Location {
   constructor(parameters) {
@@ -358,6 +358,7 @@ export async function countStart() {
   document.getElementById("simulation_bottleneck_process").value =
     bottleneck_process;
   document.getElementById("simulation_waiting_time").value = waitingTime;
+  displayRaiseOperator();
   alert("シミュレーション終了");
 }
 

--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -1,6 +1,7 @@
 import anime from "animejs";
 import { routes, facilities } from "src/set_simulation_params";
 import { drawLink } from "src/canvas";
+import { displayOperator } from "src/canvas";
 
 class Location {
   constructor(parameters) {
@@ -204,6 +205,8 @@ function dispCount(t) {
 
 export async function countStart() {
   let controlsProgress = document.querySelector("#simulation input.progress");
+  await displayOperator();
+  // await displayStartGoalName();
 
   if (controlsProgress) {
     controlsProgress.value = 0;

--- a/app/javascript/test/__snapshots__/canvas.test.js.snap
+++ b/app/javascript/test/__snapshots__/canvas.test.js.snap
@@ -72,30 +72,54 @@ exports[`draw link and circle 1`] = `
       y1="310"
       y2="87.8543007265578"
     />
-    <circle
-      cx="230"
-      cy="310"
-      fill="#99aaee"
-      id="start"
-      r="10"
-      stroke="black"
-    />
-    <circle
-      cx="330"
-      cy="60"
-      fill="#99aaee"
-      id="1"
-      r="15"
-      stroke="black"
-    />
-    <circle
-      cx="430"
-      cy="310"
-      fill="#99aaee"
-      id="goal"
-      r="10"
-      stroke="black"
-    />
+    <g
+      transform="translate(230, 310)"
+    >
+      <circle
+        fill="#99aaee"
+        id="start"
+        r="10"
+        stroke="black"
+      />
+      <text
+        text-anchor="middle"
+        y="25"
+      >
+        start
+      </text>
+    </g>
+    <g
+      transform="translate(330, 60)"
+    >
+      <circle
+        fill="#99aaee"
+        id="1"
+        r="15"
+        stroke="black"
+      />
+      <text
+        text-anchor="middle"
+        y="25"
+      >
+        1
+      </text>
+    </g>
+    <g
+      transform="translate(430, 310)"
+    >
+      <circle
+        fill="#99aaee"
+        id="goal"
+        r="10"
+        stroke="black"
+      />
+      <text
+        text-anchor="middle"
+        y="25"
+      >
+        goal
+      </text>
+    </g>
   </svg>
   
   

--- a/app/javascript/test/canvas.test.js
+++ b/app/javascript/test/canvas.test.js
@@ -68,8 +68,8 @@ test("draw link and circle", async () => {
   await drawLink(routesInitial, facilitiesInitial);
 
   await waitFor(() => {
-    const circle = document.querySelector("circle");
-    expect(circle).toHaveAttribute("cx"); // cxが設定されていることを確認
+    const group = document.querySelector("g");
+    expect(group).toHaveAttribute("transform");
   });
 
   expect(div).toMatchSnapshot();

--- a/app/views/simulations/_form.html.erb
+++ b/app/views/simulations/_form.html.erb
@@ -169,13 +169,12 @@ data-facilities ="<%= @simulation.facilities %>">
   </div>
 
   <div class="w-full overflow-scroll">
-    <svg id="svg02" class="h-[500px] w-[500px]" xmlns="http://www.w3.org/2000/svg">
+    <svg id="svg02" class="h-[500px] w-[500px] md:w-full" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <marker id="arr" refX="0" refY="1" orient="auto">
           <path d="M0,0 L2,1 0,2 Z" fill="#eab942" />
         </marker>
       </defs>
-      <text id="ob1" x="0" y="20">作業者</text>
     </svg>
   </div>
 </div>


### PR DESCRIPTION
作業者の文字はシミュレーション実行時に初めて出現させる

ノードに文字上を追加（start/goal/ノード番号)

svgのデザインを変更。枠を広くした。


SVG上のノードと文字をグループにした。それに伴いテストも修正