### PR TITLE
ボトルネックがstartの場合は「なし」とした。

### DIFF
--- a/app/javascript/src/exec_simulation.js
+++ b/app/javascript/src/exec_simulation.js
@@ -397,6 +397,9 @@ export function judgeBottleneckProcess(waitingArray) {
     (element) => element[1] == waitingTime
   );
   let bottleneck_process = bottleneck_map[0];
+  if (bottleneck_process == "start") {
+    bottleneck_process = "なし(移動ネック)";
+  }
   return bottleneck_process;
 }
 


### PR DESCRIPTION
ふつうの計算ではボトルネックがない場合もstartと表示される。

わかりにくいため、「なし（移動ネック）」とする。