### PR TITLE
読み込み時のクリックイベントが発火するように修正

### DIFF
--- a/app/javascript/src/simulation.js
+++ b/app/javascript/src/simulation.js
@@ -26,8 +26,8 @@ import {
   linkMouseOut,
 } from "src/canvas";
 let ghostNode, tempLine;
-const svg = d3.select("#svg02");
 export async function setClickEventToObject(object) {
+  const svg = d3.select("#svg02");
   switch (object.state) {
     case "edit":
       console.log("edit");
@@ -63,6 +63,7 @@ export async function setClickEventToObject(object) {
 }
 
 export function switchDeleteObjectMode() {
+  const svg = d3.select("#svg02");
   clearGhostObjects();
   removeSelectAttribute();
 
@@ -77,6 +78,7 @@ export function switchDeleteObjectMode() {
 }
 
 export function switchAddFacilityMode() {
+  const svg = d3.select("#svg02");
   clearGhostObjects();
   removeSelectAttribute();
 
@@ -106,6 +108,7 @@ export function switchAddFacilityMode() {
 }
 
 export function switchAddRouteMode() {
+  const svg = d3.select("#svg02");
   clearGhostObjects();
   removeSelectAttribute();
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Widget', type: :system do
+RSpec.describe 'RenderSVG', type: :system do
   before do
     @confirmed_user = User.create!(name: 'satou2', email: 'satou2@example.com', password: 'password',
                                    confirmed_at: DateTime.now)
@@ -18,13 +18,20 @@ RSpec.describe 'Widget', type: :system do
     expect(page).to have_css 'circle#n1'
     expect(page).to have_css 'circle#goal'
   end
+end
+
+RSpec.describe 'EditObjects', type: :system do
+  before do
+    @confirmed_user = User.create!(name: 'satou2', email: 'satou2@example.com', password: 'password',
+                                   confirmed_at: DateTime.now)
+  end
 
   it 'can edit facility attributes', js: true do
     sign_in @confirmed_user
     visit new_user_simulation_path(@confirmed_user)
     find('circle#n1').click
-    fill_in '設備名' , with: '変更後の設備名' ,fill_options: { clear: :backspace }
-    fill_in '加工時間' , with: '30' ,fill_options: { clear: :backspace }
+    fill_in '設備名', with: '変更後の設備名', fill_options: { clear: :backspace }
+    fill_in '加工時間', with: '30', fill_options: { clear: :backspace }
     click_on '保存'
     expect(page).to have_css 'circle#n1'
   end
@@ -33,7 +40,7 @@ RSpec.describe 'Widget', type: :system do
     sign_in @confirmed_user
     visit new_user_simulation_path(@confirmed_user)
     find('line#root1-1').click
-    fill_in '距離' , with: '30' ,fill_options: { clear: :backspace }
+    fill_in '距離', with: '30', fill_options: { clear: :backspace }
     click_on '保存'
     expect(page).to have_css 'line#root1-1'
   end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -18,4 +18,23 @@ RSpec.describe 'Widget', type: :system do
     expect(page).to have_css 'circle#n1'
     expect(page).to have_css 'circle#goal'
   end
+
+  it 'can edit facility attributes', js: true do
+    sign_in @confirmed_user
+    visit new_user_simulation_path(@confirmed_user)
+    find('circle#n1').click
+    fill_in '設備名' , with: '変更後の設備名' ,fill_options: { clear: :backspace }
+    fill_in '加工時間' , with: '30' ,fill_options: { clear: :backspace }
+    click_on '保存'
+    expect(page).to have_css 'circle#n1'
+  end
+
+  it 'can edit link attributes', js: true do
+    sign_in @confirmed_user
+    visit new_user_simulation_path(@confirmed_user)
+    find('line#root1-1').click
+    fill_in '距離' , with: '30' ,fill_options: { clear: :backspace }
+    click_on '保存'
+    expect(page).to have_css 'line#root1-1'
+  end
 end


### PR DESCRIPTION
ページ遷移したときに、ノードとリンクのクリックイベントが発火しないバグがあった。
それを修正した。