### PR TITLE
ヘッダーの文面修正とハンバーガーメニューが開くように修正

### DIFF
--- a/app/javascript/src/simulation.js
+++ b/app/javascript/src/simulation.js
@@ -356,3 +356,15 @@ export async function setSimulationSaveEvent() {
     });
   }
 }
+
+function toggleUserMenu() {
+  let userMenu = document.getElementById("userMenu");
+  userMenu.classList.toggle("hidden");
+}
+
+document.addEventListener("turbo:load", () => {
+  const userMenu = document.getElementById("user-menu-button");
+  if (userMenu) {
+    userMenu.addEventListener("click", toggleUserMenu, false);
+  }
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,11 +27,10 @@
                 <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-indigo-700 hover:text-white" -->
                 <% if user_signed_in? %>
                   <%= link_to "シミュレーション一覧", user_simulations_path(current_user) ,class: "rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white" %>
-                  <%= link_to "会員編集編集", edit_user_registration_path, class:"dropdown-item  rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white" %>
+                  <%= link_to "会員情報編集", edit_user_registration_path, class:"dropdown-item  rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white" %>
                   <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo_confirm: "ログアウトしますか？" } ,form_class: "rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white"%>
-                  <span class="rounded-md px-3 py-2 text-gray-300">【ログイン中のアドレス】 <%= current_user.email %></span>
+                  <span class="rounded-md px-3 py-2 text-gray-300"> <%= current_user.email %></span>
                 <% else %>
-                  <a href="/demo" class="rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-indigo-700 hover:text-white" aria-current="page">使ってみる</a>
                   <%= link_to "新規登録", new_user_registration_path ,class: "nav-link2 rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-indigo-700 hover:text-white" %>
                   <%= link_to "ログイン", new_user_session_path ,class: "nav-link2 rounded-md px-3 py-2 text-sm font-medium text-gray-300 hover:bg-indigo-700 hover:text-white" %>
                 <% end %>
@@ -66,9 +65,8 @@
                 <%= link_to "シミュレーション一覧", user_simulations_path(current_user) ,class: "block px-4 py-2 text-sm text-gray-700" %>
                 <%= link_to "会員情報編集", edit_user_registration_path, class:"block px-4 py-2 text-sm text-gray-700" %>
                 <%= button_to "ログアウト",destroy_user_session_path, {method: :delete, data: { turbo_confirm: "ログアウトしますか？" }, form_class: "block px-4 py-2 text-sm text-gray-700"} %>
-                <span class="block px-4 py-2 text-sm text-gray-700">【ログイン中のアドレス】<%= current_user.email %></span>
+                <span class="block px-4 py-2 text-sm text-gray-700"><%= current_user.email %></span>
               <% else %>
-                <a href="/demo" class="block px-4 py-2 text-sm text-gray-700" aria-current="page">デモを試す</a>
                 <%= link_to "会員登録", new_user_registration_path ,class: "block px-4 py-2 text-sm text-gray-700" %>
                 <%= link_to "ログイン", new_user_session_path ,class: "block px-4 py-2 text-sm text-gray-700" %>
               <% end %>


### PR DESCRIPTION
文面を修正したら、ハンバーガーメニューが開かなくなっていたことに気づいた。

過去に削除したファイルから、メニューを開く関数をコピーして既存に貼り付けした。


「デモを試す」というヘッダーのリンクは削除した。