### PR TITLE
データの作成数に上限を設けた

### DIFF
--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -1,4 +1,11 @@
 class Simulation < ApplicationRecord
   belongs_to :user
   validates :title, length: { maximum: 20 }, presence: true
+  validate :simulation_total_count_cannot_set_exceeded_limit, on: :create
+
+  SIMULATION_MAX_COUNT = 3
+  def simulation_total_count_cannot_set_exceeded_limit
+    count_in_simulation = user.simulations.count
+    errors.add(:status, 'シミュレーションの総数は3個までです') if count_in_simulation >= SIMULATION_MAX_COUNT
+  end
 end

--- a/app/views/simulations/index.html.erb
+++ b/app/views/simulations/index.html.erb
@@ -5,7 +5,14 @@
   <h1 class="text-3xl font-bold tracking-tight text-gray-900">シミュレーション一覧</h1>
   <% if @simulations.length != 0 %>
   <div class="mx-auto max-w-7xl pt-4 px-4 sm:px-6 lg:px-8 text-right">
-    <%= link_to "新規作成", new_user_simulation_path(current_user), class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+    <% if @simulations.length >= Simulation::SIMULATION_MAX_COUNT %>
+      <button type="button" id="play" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-gray shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:bg-gray-300" disabled>
+      新規作成
+      </button>
+      シミュレーション数が上限に達しています。
+    <% else %>
+      <%= link_to "新規作成", new_user_simulation_path(current_user), class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+    <% end %>
   </div>
   <% end %>
   <div id="simurates" class="mx-auto py-8 max-w-4xl">

--- a/spec/system/simulations_spec.rb
+++ b/spec/system/simulations_spec.rb
@@ -72,3 +72,19 @@ RSpec.describe 'UpdateAndDeleteSimulation', type: :system do
     expect(page).to have_content 'シミュレーションが削除されました。'
   end
 end
+
+RSpec.describe 'LimitSimulation', type: :system do
+  before do
+    @user = User.create!(name: 'alice', email: 'alice@example.com', password: 'password',
+                         confirmed_at: DateTime.now)
+    @user.simulations.create!(title: 'test-simulation1')
+    @user.simulations.create!(title: 'test-simulation2')
+    @user.simulations.create!(title: 'test-simulation3')
+  end
+
+  it 'cannot create simulation beyond the limit ', js: true do
+    sign_in @user
+    visit user_simulations_path(@user)
+    expect(page).to have_content 'シミュレーション数が上限に達しています。'
+  end
+end


### PR DESCRIPTION
シミュレーションを作成できるのは最大三つまでとした。
バリデーションの作成と、フロント側も変更。
