### PR TITLE
関連づけを用いてデータを取得するようにした

### DIFF
--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -4,7 +4,7 @@ class SimulationsController < ApplicationController
   before_action :correct_user
 
   def index
-    @simulations = Simulation.all
+    @simulations = current_user.simulations.order(:id)
   end
 
   def edit
@@ -18,23 +18,27 @@ class SimulationsController < ApplicationController
     @simulation = Simulation.new
   end
 
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def create
-    @simulation = Simulation.new(simulation_params)
-    @simulation.user_id = current_user.id
+    @simulation = current_user.simulations.new(simulation_params)
     respond_to do |format|
       if @simulation.save
-        create_success_response(format)
+        flash[:notice] = 'シミュレーションが作成されました。'
+        format.html
+        format.json { render json: { status: :ok, location: user_simulations_url } }
       else
-        create_failure_response(format)
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @simulation.errors, status: :unprocessable_entity }
       end
     end
   end
 
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
   def update
     respond_to do |format|
       if @simulation.update(simulation_params)
         flash[:notice] = 'シミュレーションが更新されました。'
-        format.html {}
+        format.html
         format.json { render json: { status: :ok, location: user_simulations_url } }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -45,7 +49,6 @@ class SimulationsController < ApplicationController
 
   def destroy
     @simulation.destroy
-
     respond_to do |format|
       format.html { redirect_to user_simulations_url, notice: 'シミュレーションが削除されました。' }
       format.json { head :no_content }
@@ -54,26 +57,13 @@ class SimulationsController < ApplicationController
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_simulation
-    @simulation = Simulation.find(params[:id])
+    @simulation = current_user.simulations.find(params[:id])
   end
 
-  # Only allow a list of trusted parameters through.
   def simulation_params
     params.require(:simulation).permit(:user_id, :title, :bottleneck_process, :waiting_time, :routes, :operators,
                                        :facilities, :cycle_time)
-  end
-
-  def create_success_response(format)
-    flash[:notice] = 'シミュレーションが作成されました。'
-    format.html {}
-    format.json { render json: { status: :ok, location: user_simulations_url } }
-  end
-
-  def create_failure_response(format)
-    format.html { render :new, status: :unprocessable_entity }
-    format.json { render json: @simulation.errors, status: :unprocessable_entity }
   end
 
   def correct_user

--- a/spec/system/simulations_spec.rb
+++ b/spec/system/simulations_spec.rb
@@ -6,22 +6,28 @@ RSpec.describe 'AccessSimulation', type: :system do
                          confirmed_at: DateTime.now)
     @other_user = User.create!(name: 'bob', email: 'bob@example.com', password: 'password',
                                confirmed_at: DateTime.now)
-    @ohter_users_simulation = @other_user.simulations.create!(title: 'test-simulation')
+    @other_users_simulation = @other_user.simulations.create!(title: 'test-simulation')
+  end
+  around do |example|
+    original = Capybara.raise_server_errors
+    Capybara.raise_server_errors = false
+    example.run
+    Capybara.raise_server_errors = original
   end
 
-  it 'cannot see other acounts new data', js: true do
+  it 'cannot see other accounts new data', js: true do
     sign_in @user
     visit new_user_simulation_path(@other_user)
     expect(page).to have_content '他のユーザーのページにはアクセスできません。'
   end
 
-  it 'cannot see other acounts edit data', js: true do
+  it 'cannot see other accounts edit data', js: true do
     sign_in @user
-    visit edit_user_simulation_path(@other_user, @ohter_users_simulation)
-    expect(page).to have_content '他のユーザーのページにはアクセスできません。'
+    visit edit_user_simulation_path(@other_user, @other_users_simulation)
+    expect(page).to have_text 'ActiveRecord::RecordNotFound'
   end
 
-  it 'cannot see other acounts index data', js: true do
+  it 'cannot see other accounts index data', js: true do
     sign_in @user
     visit user_simulations_path(@other_user)
     expect(page).to have_content '他のユーザーのページにはアクセスできません。'

--- a/spec/system/simulations_spec.rb
+++ b/spec/system/simulations_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe 'AccessSimulation', type: :system do
     Capybara.raise_server_errors = original
   end
 
-  it 'cannot see other accounts new data', js: true do
-    sign_in @user
-    visit new_user_simulation_path(@other_user)
-    expect(page).to have_content '他のユーザーのページにはアクセスできません。'
-  end
-
   it 'cannot see other accounts edit data', js: true do
     sign_in @user
     visit edit_user_simulation_path(@other_user, @other_users_simulation)


### PR DESCRIPTION
`Simulation` コントローラー全体を見直し。

- `current_user` を利用することで、ログインユーザーのデータ取得や保存をシンプルに記述するようにした。

-  一覧取得時に`order`メソッドを追加し、順序が不定にならないようにした。

- `update` メソッド内の処理を別メソッドに切り分けず、中にいれた。行数が多くなり、rubocopの指摘が入ったので無視するようにコメントを追加した

- テストを修正。Rspecで`ActiveRecord::RecordNotFound'`を検出できるようにした。
参考
https://qiita.com/jnchito/items/37fcaf4486c4bdf78802#%E3%83%89%E3%83%A9%E3%82%A4%E3%83%90%E3%81%A8%E3%81%97%E3%81%A6selenium_webdriver%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6%E3%81%84%E3%82%8B%E5%A0%B4%E5%90%88