### PR TITLE
ルーティング修正

### DIFF
--- a/app/controllers/demos_controller.rb
+++ b/app/controllers/demos_controller.rb
@@ -1,7 +1,7 @@
 class DemosController < ApplicationController
   def new
     if user_signed_in?
-      redirect_to new_user_simulation_path(current_user.id)
+      redirect_to new_simulation_path(current_user.id)
       return
     end
     @simulation = Simulation.new

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -1,7 +1,6 @@
 class SimulationsController < ApplicationController
   before_action :authenticate_user!, except: :new
   before_action :set_simulation, only: %i[edit update destroy]
-  before_action :correct_user
 
   def index
     @simulations = current_user.simulations.order(:id)
@@ -18,31 +17,25 @@ class SimulationsController < ApplicationController
     @simulation = Simulation.new
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def create
     @simulation = current_user.simulations.new(simulation_params)
     respond_to do |format|
       if @simulation.save
         flash[:notice] = 'シミュレーションが作成されました。'
         format.html
-        format.json { render json: { status: :ok, location: user_simulations_url } }
       else
         format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @simulation.errors, status: :unprocessable_entity }
       end
     end
   end
 
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
   def update
     respond_to do |format|
       if @simulation.update(simulation_params)
         flash[:notice] = 'シミュレーションが更新されました。'
         format.html
-        format.json { render json: { status: :ok, location: user_simulations_url } }
       else
         format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: { status: 'error', errors: @simulation.errors.full_messages }, status: :ok }
       end
     end
   end
@@ -50,8 +43,7 @@ class SimulationsController < ApplicationController
   def destroy
     @simulation.destroy
     respond_to do |format|
-      format.html { redirect_to user_simulations_url, notice: 'シミュレーションが削除されました。' }
-      format.json { head :no_content }
+      format.html { redirect_to simulations_url, notice: 'シミュレーションが削除されました。' }
     end
   end
 
@@ -66,11 +58,4 @@ class SimulationsController < ApplicationController
                                        :facilities, :cycle_time)
   end
 
-  def correct_user
-    @user = User.find(params[:user_id])
-    return unless @user != current_user
-
-    flash[:alert] = '他のユーザーのページにはアクセスできません。'
-    redirect_to(root_url)
-  end
 end

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -57,5 +57,4 @@ class SimulationsController < ApplicationController
     params.require(:simulation).permit(:user_id, :title, :bottleneck_process, :waiting_time, :routes, :operators,
                                        :facilities, :cycle_time)
   end
-
 end

--- a/app/controllers/welcomes_controller.rb
+++ b/app/controllers/welcomes_controller.rb
@@ -1,5 +1,5 @@
 class WelcomesController < ApplicationController
   def show
-    redirect_to user_simulations_path(current_user.id) if user_signed_in?
+    redirect_to simulations_path(current_user.id) if user_signed_in?
   end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -10,7 +10,7 @@
         <div class="hidden md:ml-6 md:block">
           <div class="flex space-x-4">
             <% if user_signed_in? %>
-              <%= link_to "シミュレーション一覧", user_simulations_path(current_user) ,class: "rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white" %>
+              <%= link_to "シミュレーション一覧", simulations_path ,class: "rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white" %>
               <%= link_to "会員情報編集", edit_user_registration_path, class:"dropdown-item  rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white" %>
               <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo_confirm: "ログアウトしますか？" } ,form_class: "rounded-md px-3 py-2 text-gray-300 hover:bg-indigo-700 hover:text-white"%>
               <span class="rounded-md px-3 py-2 text-gray-300"> <%= current_user.email %></span>
@@ -33,7 +33,7 @@
           </div>
           <div class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none hidden" id= "userMenu" role="menu" aria-orientation="vertical" aria-labelledby="user-menu-button" tabindex="-1">
             <% if user_signed_in? %>
-              <%= link_to "シミュレーション一覧", user_simulations_path(current_user) ,class: "block px-4 py-2 text-sm text-gray-700" %>
+              <%= link_to "シミュレーション一覧", simulations_path ,class: "block px-4 py-2 text-sm text-gray-700" %>
               <%= link_to "会員情報編集", edit_user_registration_path, class:"block px-4 py-2 text-sm text-gray-700" %>
               <%= button_to "ログアウト",destroy_user_session_path, {method: :delete, data: { turbo_confirm: "ログアウトしますか？" }, form_class: "block px-4 py-2 text-sm text-gray-700"} %>
               <span class="block px-4 py-2 text-sm text-gray-700"><%= current_user.email %></span>

--- a/app/views/simulations/_result_window.html.erb
+++ b/app/views/simulations/_result_window.html.erb
@@ -69,7 +69,7 @@
     <% end %>
 
     <% if user_signed_in? %>
-      <%= form_with(model: @simulation ,url: [current_user , @simulation] ,data: { turbo_frame: "simulation-modal" ,action: "turbo:submit-end->simulation-mode#close" }, id: "simulationForm") do |form| %>
+      <%= form_with(model: @simulation ,url: @simulation ,data: { turbo_frame: "simulation-modal" ,action: "turbo:submit-end->simulation-mode#close" }, id: "simulationForm") do |form| %>
         <div class="">
           <div class="flex">
             <%= form.hidden_field :routes , id: "simulation-routes" %>

--- a/app/views/simulations/index.html.erb
+++ b/app/views/simulations/index.html.erb
@@ -11,7 +11,7 @@
       </button>
       シミュレーション数が上限に達しています。
     <% else %>
-      <%= link_to "新規作成", new_user_simulation_path(current_user), class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+      <%= link_to "新規作成", new_simulation_path, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
     <% end %>
   </div>
   <% end %>
@@ -20,7 +20,7 @@
       <% if @simulations.length == 0 %>
       シミュレーションデータがありません。データの新規作成を行ってください。
       <div class="mx-auto max-w-7xl pt-4 px-4 sm:px-6 lg:px-8 text-right">
-        <%= link_to "新規作成", new_user_simulation_path(current_user), class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+        <%= link_to "新規作成", new_simulation_path, class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
       </div>
 
       <% else %>
@@ -33,8 +33,8 @@
             <p class="mt-1 truncate text-xs/5 text-gray-500">待ち時間:<%= simulation.waiting_time %></p>
           </div>
           <div class="flex shrink-0 items-center gap-x-4">
-            <%= link_to "編集", edit_user_simulation_path(current_user, simulation) ,class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-            <%= link_to "削除", user_simulation_path(current_user, simulation), data: { turbo_method: :delete ,turbo_confirm: "本当に削除しますか？" } ,class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+            <%= link_to "編集", edit_simulation_path(simulation) ,class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+            <%= link_to "削除", simulation_path(simulation), data: { turbo_method: :delete ,turbo_confirm: "本当に削除しますか？" } ,class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
           </div>
         </li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,8 @@ Rails.application.routes.draw do
   resource :welcomes, only: [:show]
 
   devise_for :users
-  resources :users do
-    resources :simulations, except: :show
-  end
+  resources :simulations, except: :show
   resource :demo, only: [:new]
-
   resource :term, only: [:show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/system/simulations_spec.rb
+++ b/spec/system/simulations_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe 'AccessSimulation', type: :system do
     visit edit_simulation_path(@other_user, @other_users_simulation)
     expect(page).to have_text 'ActiveRecord::RecordNotFound'
   end
-
-  it 'cannot see other accounts index data', js: true do
-    sign_in @user
-    visit simulations_path(@other_user)
-    expect(page).to have_content '他のユーザーのページにはアクセスできません。'
-  end
 end
 
 RSpec.describe 'SaveSimulation', type: :system do

--- a/spec/system/simulations_spec.rb
+++ b/spec/system/simulations_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe 'AccessSimulation', type: :system do
 
   it 'cannot see other accounts edit data', js: true do
     sign_in @user
-    visit edit_user_simulation_path(@other_user, @other_users_simulation)
+    visit edit_simulation_path(@other_user, @other_users_simulation)
     expect(page).to have_text 'ActiveRecord::RecordNotFound'
   end
 
   it 'cannot see other accounts index data', js: true do
     sign_in @user
-    visit user_simulations_path(@other_user)
+    visit simulations_path(@other_user)
     expect(page).to have_content '他のユーザーのページにはアクセスできません。'
   end
 end
@@ -37,7 +37,7 @@ RSpec.describe 'SaveSimulation', type: :system do
 
   it 'can create new simulation', js: true do
     sign_in @user
-    visit user_simulations_path(@user)
+    visit simulations_path(@user)
     click_on('新規作成')
     click_on('結果確認/保存へ')
     fill_in 'simulation[title]', with: '生産ラインA'
@@ -55,7 +55,7 @@ RSpec.describe 'UpdateAndDeleteSimulation', type: :system do
 
   it 'can update simulation', js: true do
     sign_in @user
-    visit user_simulations_path(@user)
+    visit simulations_path(@user)
     click_on('編集')
     click_on('結果確認/保存へ')
     fill_in 'simulation[title]', with: '生産ラインB'
@@ -65,7 +65,7 @@ RSpec.describe 'UpdateAndDeleteSimulation', type: :system do
 
   it 'can delete simulation', js: true do
     sign_in @user
-    visit user_simulations_path(@user)
+    visit simulations_path(@user)
     accept_confirm do
       click_on('削除')
     end
@@ -84,7 +84,7 @@ RSpec.describe 'LimitSimulation', type: :system do
 
   it 'cannot create simulation beyond the limit ', js: true do
     sign_in @user
-    visit user_simulations_path(@user)
+    visit simulations_path(@user)
     expect(page).to have_content 'シミュレーション数が上限に達しています。'
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'RenderSVG', type: :system do
 
   it 'can see facility objects', js: true do
     sign_in @confirmed_user
-    visit new_user_simulation_path(@confirmed_user)
+    visit new_simulation_path(@confirmed_user)
     click_on '結果確認'
     fill_in 'simulation[title]', with: 'machine'
     click_on 'データを保存'
@@ -28,7 +28,7 @@ RSpec.describe 'EditObjects', type: :system do
 
   it 'can edit facility attributes', js: true do
     sign_in @confirmed_user
-    visit new_user_simulation_path(@confirmed_user)
+    visit new_simulation_path(@confirmed_user)
     find('circle#n1').click
     fill_in '設備名', with: '変更後の設備名', fill_options: { clear: :backspace }
     fill_in '加工時間', with: '30', fill_options: { clear: :backspace }
@@ -38,7 +38,7 @@ RSpec.describe 'EditObjects', type: :system do
 
   it 'can edit link attributes', js: true do
     sign_in @confirmed_user
-    visit new_user_simulation_path(@confirmed_user)
+    visit new_simulation_path(@confirmed_user)
     find('line#root1-1').click
     fill_in '距離', with: '30', fill_options: { clear: :backspace }
     click_on '保存'
@@ -54,7 +54,7 @@ RSpec.describe 'AddDeleteObjects', type: :system do
 
   it 'can add and link facility', js: true do
     sign_in @confirmed_user
-    visit new_user_simulation_path(@confirmed_user)
+    visit new_simulation_path(@confirmed_user)
     find("label[for='add-facility']").click
     find('svg#svg02').click(x: 0, y: 0)
 
@@ -69,7 +69,7 @@ RSpec.describe 'AddDeleteObjects', type: :system do
 
   it 'can delete facility', js: true do
     sign_in @confirmed_user
-    visit new_user_simulation_path(@confirmed_user)
+    visit new_simulation_path(@confirmed_user)
     find("label[for='delete-object']").click
     find('circle#n1').click
     accept_alert
@@ -84,9 +84,9 @@ RSpec.describe 'DeletionErrors', type: :system do
                                    confirmed_at: DateTime.now)
   end
 
-  it 'cannot add dupulicate goal and link', js: true do
+  it 'cannot add duplicate goal and link', js: true do
     sign_in @confirmed_user
-    visit new_user_simulation_path(@confirmed_user)
+    visit new_simulation_path(@confirmed_user)
     find("label[for='add-link']").click
     find('circle#start').click
     find('circle#n1').click

--- a/spec/system/visit_page_spec.rb
+++ b/spec/system/visit_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'VisitSimulationPage', type: :system do
 
   it 'visiting the index simulation when sign in' do
     sign_in @confirmed_user
-    visit user_simulations_path(@confirmed_user)
+    visit simulations_path(@confirmed_user)
     assert_selector 'h1', text: 'シミュレーション一覧'
   end
 


### PR DESCRIPTION
#235 

シミュレーションのパスにユーザーIDを含めないようにした。自分のデータしか閲覧することはないため。

これによってリンクも変更。


`Simulation` コントローラーに書いているが、使っていないjsonの記述は削除した。
editアクションのときは必要なので残している。