### PR TITLE
edit.jsonを呼ばずにviewのdata属性を利用する

### DIFF
--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -7,9 +7,7 @@ class SimulationsController < ApplicationController
   end
 
   def edit
-    respond_to do |format|
-      format.html
-    end
+    respond_to(&:html)
   end
 
   def new

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -9,7 +9,6 @@ class SimulationsController < ApplicationController
   def edit
     respond_to do |format|
       format.html
-      format.json { render json: @simulation }
     end
   end
 

--- a/app/javascript/src/loader.js
+++ b/app/javascript/src/loader.js
@@ -1,13 +1,9 @@
 export async function loadObjects() {
-  try {
-    const response = await fetch("edit.json");
-    if (!response.ok) {
-      throw new Error(`レスポンスステータス: ${response.status}`);
-    }
-    const json = await response.json();
-    const routes = JSON.parse(json.routes);
-    const facilities = JSON.parse(json.facilities);
-    const operators = JSON.parse(json.operators);
+  const simulationData = document.getElementById("simulation-data");
+  if (simulationData) {
+    const routes = JSON.parse(simulationData.dataset.routes);
+    const facilities = JSON.parse(simulationData.dataset.facilities);
+    const operators = JSON.parse(simulationData.dataset.operators);
 
     routes.forEach((route) => {
       if (typeof route.source === "object") {
@@ -18,7 +14,5 @@ export async function loadObjects() {
       }
     });
     return { routes, facilities, operators };
-  } catch (error) {
-    console.error(error.message);
   }
 }

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'RenderSVG', type: :system do
   it 'can see facility objects', js: true do
     sign_in @confirmed_user
     visit new_simulation_path
-    # sleep 3
     click_on '結果確認'
     fill_in 'simulation[title]', with: 'machine'
     click_on 'データを保存'
@@ -29,7 +28,7 @@ RSpec.describe 'EditObjects', type: :system do
 
   it 'can edit facility attributes', js: true do
     visit new_simulation_path
-    sleep 3
+    # sleep 3
     find('circle#n1').click
     fill_in '設備名', with: '変更後の設備名', fill_options: { clear: :backspace }
     fill_in '加工時間', with: '30', fill_options: { clear: :backspace }
@@ -39,11 +38,11 @@ RSpec.describe 'EditObjects', type: :system do
 
   it 'can edit link attributes', js: true do
     visit new_simulation_path
-    sleep 3
+    # sleep 3
     find('line#root1-1').click
     fill_in '距離', with: '30', fill_options: { clear: :backspace }
     click_on '保存'
-    sleep 3
+    # sleep 3
     find('line#root1-1').click
     expect(page).to have_css('line#root1-1', wait: 5, visible: :all)
   end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'EditObjects', type: :system do
 
   it 'can edit facility attributes', js: true do
     visit new_simulation_path
-    # sleep 3
+    sleep 3
     find('circle#n1').click
     fill_in '設備名', with: '変更後の設備名', fill_options: { clear: :backspace }
     fill_in '加工時間', with: '30', fill_options: { clear: :backspace }
@@ -38,7 +38,7 @@ RSpec.describe 'EditObjects', type: :system do
 
   it 'can edit link attributes', js: true do
     visit new_simulation_path
-    # sleep 3
+    sleep 3
     find('line#root1-1').click
     fill_in '距離', with: '30', fill_options: { clear: :backspace }
     click_on '保存'


### PR DESCRIPTION
パラメータをロードするときに`edit.json`を呼び出していたが、
すでにviewのdata属性に同じ値を使っていた。

`edit.json`を呼び出さずにdata属性を読み込むことで、描画に要する時間を短縮させる。